### PR TITLE
Add ad-free requirement to setup documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ A comprehensive KOReader plugin that displays beautiful weather information on y
         </li>
         <li>Navigate to <b>Settings &gt; Screen  &gt;  Sleep Screen  &gt;  Wallpaper </b></li>
           <ul>
-            <li>KOReader's "Sleep Screen" option is only exposed if you have ads disabled.</li>
+            <li><a href="https://github.com/koreader/koreader/issues/14098">KOReader's "Sleep Screen" option is only exposed if you have ads disabled</a>.</li>
           </ul>
         <li>Select <b>"Show weather on sleep screen" </b></li>
       </ol>


### PR DESCRIPTION
Perhaps most people already ~~hacked away~~ _paid Amazon to remove_ lock screen ads so haven't run into this issue; I hadn't done that on my paperwhite and thought I'd done something wrong during setup as this is the first extension I've installed.